### PR TITLE
Remove redundant variable declarations and statements

### DIFF
--- a/gcp/project.tf
+++ b/gcp/project.tf
@@ -1,4 +1,5 @@
 variable "project_id" {}
+variable "role_bindings" {}
 variable "project_name" {}
 variable "org_id" {}
 variable "folder_id" {}

--- a/gcp/project.tf
+++ b/gcp/project.tf
@@ -3,7 +3,6 @@ variable "role_bindings" {}
 variable "project_name" {}
 variable "org_id" {}
 variable "folder_id" {}
-variable "skip_delete" {}
 variable "billing_id" {}
 
 resource "google_project" "project" {

--- a/gcp/project.tf
+++ b/gcp/project.tf
@@ -1,20 +1,15 @@
 variable "project_id" {}
-variable "role_bindings" {}
 variable "project_name" {}
 variable "org_id" {}
 variable "folder_id" {}
-variable "region" {}
 variable "skip_delete" {}
 variable "billing_id" {}
-
-provider "google" {
- region = "${var.region}"
-}
 
 resource "google_project" "project" {
  name            = "${var.project_name}"
  project_id      = "${var.project_id}"
  billing_account = "${var.billing_id}"
+ folder_id       = "${var.folder_id}"
 }
 
 resource "google_project_service" "project" {
@@ -26,4 +21,3 @@ resource "google_project_service" "project" {
 output "project_id" {
  value = "${google_project.project.project_id}"
 }
-


### PR DESCRIPTION
As @SaltyMesoform mentioned, `terraform plan` command throws warnings about undeclared variables. So, I removed declarations from `.tf` file and removed redundant variables files from `eCat` repo.

Also, I added `folder_id` to `google_project` resource, because previously it was unused.