### PR TITLE
Use skip_delete and remove template interpolation syntax

### DIFF
--- a/gcp/project.tf
+++ b/gcp/project.tf
@@ -6,18 +6,19 @@ variable "skip_delete" {}
 variable "billing_id" {}
 
 resource "google_project" "project" {
- name            = "${var.project_name}"
- project_id      = "${var.project_id}"
- billing_account = "${var.billing_id}"
- folder_id       = "${var.folder_id}"
+ name            = var.project_name
+ project_id      = var.project_id
+ billing_account = var.billing_id
+ folder_id       = var.folder_id
+ skip_delete     = var.skip_delete
 }
 
 resource "google_project_service" "project" {
-  project = "${google_project.project.project_id}"
+  project = google_project.project.project_id
   service = "compute.googleapis.com"
   disable_on_destroy = false
 }
 
 output "project_id" {
- value = "${google_project.project.project_id}"
+ value = google_project.project.project_id
 }


### PR DESCRIPTION
1) Fixed this:
```
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```
2) Added using of `skip_delete` variable.